### PR TITLE
Use relative imports within nnunetv2 package

### DIFF
--- a/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
+++ b/nnunetv2/experiment_planning/experiment_planners/default_experiment_planner.py
@@ -9,16 +9,16 @@ from dynamic_network_architectures.architectures.unet import PlainConvUNet
 from dynamic_network_architectures.building_blocks.helper import convert_dim_to_conv_op, get_matching_instancenorm
 
 ANISO_THRESHOLD = 3
-from nnunetv2.experiment_planning.experiment_planners.network_topology import get_pool_and_conv_props
-from nnunetv2.imageio.reader_writer_registry import determine_reader_writer_from_dataset_json
-from nnunetv2.paths import nnUNet_raw, nnUNet_preprocessed
-from nnunetv2.preprocessing.normalization.map_channel_name_to_normalization import get_normalization_scheme
-from nnunetv2.preprocessing.resampling.default_resampling import resample_data_or_seg_to_shape, compute_new_shape
-from nnunetv2.utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
-from nnunetv2.utilities.default_n_proc_DA import get_allowed_n_proc_DA
-from nnunetv2.utilities.get_network_from_plans import get_network_from_plans
-from nnunetv2.utilities.json_export import recursive_fix_for_json_export
-from nnunetv2.utilities.utils import get_filenames_of_train_images_and_targets
+from .network_topology import get_pool_and_conv_props
+from ...imageio.reader_writer_registry import determine_reader_writer_from_dataset_json
+from ...paths import nnUNet_raw, nnUNet_preprocessed
+from ...preprocessing.normalization.map_channel_name_to_normalization import get_normalization_scheme
+from ...preprocessing.resampling.default_resampling import resample_data_or_seg_to_shape, compute_new_shape
+from ...utilities.dataset_name_id_conversion import maybe_convert_to_dataset_name
+from ...utilities.default_n_proc_DA import get_allowed_n_proc_DA
+from ...utilities.get_network_from_plans import get_network_from_plans
+from ...utilities.json_export import recursive_fix_for_json_export
+from ...utilities.utils import get_filenames_of_train_images_and_targets
 
 
 class ExperimentPlanner(object):

--- a/nnunetv2/inference/data_iterators.py
+++ b/nnunetv2/inference/data_iterators.py
@@ -9,9 +9,9 @@ import numpy as np
 import torch
 from batchgenerators.dataloading.data_loader import DataLoader
 
-from nnunetv2.preprocessing.preprocessors.default_preprocessor import DefaultPreprocessor
-from nnunetv2.utilities.label_handling.label_handling import convert_labelmap_to_one_hot
-from nnunetv2.utilities.plans_handling.plans_handler import PlansManager, ConfigurationManager
+from ..preprocessing.preprocessors.default_preprocessor import DefaultPreprocessor
+from ..utilities.label_handling.label_handling import convert_labelmap_to_one_hot
+from ..utilities.plans_handling.plans_handler import PlansManager, ConfigurationManager
 
 
 def preprocess_fromfiles_save_to_queue(list_of_lists: List[List[str]],

--- a/nnunetv2/inference/export_prediction.py
+++ b/nnunetv2/inference/export_prediction.py
@@ -6,8 +6,8 @@ from acvl_utils.cropping_and_padding.bounding_boxes import insert_crop_into_imag
 from batchgenerators.utilities.file_and_folder_operations import load_json, save_pickle
 
 default_num_processes = 8
-from nnunetv2.utilities.label_handling.label_handling import LabelManager
-from nnunetv2.utilities.plans_handling.plans_handler import PlansManager, ConfigurationManager
+from ..utilities.label_handling.label_handling import LabelManager
+from ..utilities.plans_handling.plans_handler import PlansManager, ConfigurationManager
 
 
 def convert_predicted_logits_to_segmentation_with_correct_shape(predicted_logits: Union[torch.Tensor, np.ndarray],

--- a/nnunetv2/inference/predict_from_raw_data.py
+++ b/nnunetv2/inference/predict_from_raw_data.py
@@ -3,6 +3,7 @@ import itertools
 import multiprocessing
 import os
 from copy import deepcopy
+from pathlib import Path
 from queue import Queue
 from threading import Thread
 from time import sleep
@@ -20,17 +21,18 @@ from torch.nn.parallel import DistributedDataParallel
 from tqdm import tqdm
 
 default_num_processes = 8
-import nnunetv2
-from nnunetv2.inference.data_iterators import preprocessing_iterator_fromnpy
-from nnunetv2.inference.export_prediction import export_prediction_from_logits, \
+PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+TRAINER_SEARCH_PATH = PACKAGE_ROOT / "training" / "nnUNetTrainer"
+from .data_iterators import preprocessing_iterator_fromnpy
+from .export_prediction import export_prediction_from_logits, \
     convert_predicted_logits_to_segmentation_with_correct_shape
-from nnunetv2.inference.sliding_window_prediction import compute_gaussian, \
+from .sliding_window_prediction import compute_gaussian, \
     compute_steps_for_sliding_window
-from nnunetv2.utilities.file_path_utilities import check_workers_alive_and_busy
-from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
-from nnunetv2.utilities.helpers import empty_cache, dummy_context
-from nnunetv2.utilities.label_handling.label_handling import determine_num_input_channels
-from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
+from ..utilities.file_path_utilities import check_workers_alive_and_busy
+from ..utilities.find_class_by_name import recursive_find_python_class
+from ..utilities.helpers import empty_cache, dummy_context
+from ..utilities.label_handling.label_handling import determine_num_input_channels
+from ..utilities.plans_handling.plans_handler import PlansManager
 
 
 class nnUNetPredictor(object):
@@ -93,7 +95,7 @@ class nnUNetPredictor(object):
         configuration_manager = plans_manager.get_configuration(configuration_name)
         # restore network
         num_input_channels = determine_num_input_channels(plans_manager, configuration_manager, dataset_json)
-        trainer_class = recursive_find_python_class(join(nnunetv2.__path__[0], "training", "nnUNetTrainer"),
+        trainer_class = recursive_find_python_class(str(TRAINER_SEARCH_PATH),
                                                     trainer_name, 'nnunetv2.training.nnUNetTrainer')
         if trainer_class is None:
             raise RuntimeError(f'Unable to locate trainer class {trainer_name} in nnunetv2.training.nnUNetTrainer. '

--- a/nnunetv2/preprocessing/normalization/map_channel_name_to_normalization.py
+++ b/nnunetv2/preprocessing/normalization/map_channel_name_to_normalization.py
@@ -1,7 +1,7 @@
 from typing import Type
 
-from nnunetv2.preprocessing.normalization.default_normalization_schemes import CTNormalization, NoNormalization, \
-    ZScoreNormalization, RescaleTo01Normalization, RGBTo01Normalization, ImageNormalization
+from .default_normalization_schemes import CTNormalization, NoNormalization, ZScoreNormalization, \
+    RescaleTo01Normalization, RGBTo01Normalization, ImageNormalization
 
 channel_name_to_normalization_mapping = {
     'ct': CTNormalization,

--- a/nnunetv2/preprocessing/preprocessors/default_preprocessor.py
+++ b/nnunetv2/preprocessing/preprocessors/default_preprocessor.py
@@ -14,6 +14,7 @@
 import math
 import multiprocessing
 import shutil
+from pathlib import Path
 from time import sleep
 from typing import Tuple
 
@@ -23,11 +24,12 @@ from batchgenerators.utilities.file_and_folder_operations import *
 from tqdm import tqdm
 from typing import Union
 
-import nnunetv2
-from nnunetv2.preprocessing.cropping.cropping import crop_to_nonzero
-from nnunetv2.preprocessing.resampling.default_resampling import compute_new_shape
-from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
-from nnunetv2.utilities.plans_handling.plans_handler import PlansManager, ConfigurationManager
+from ..cropping.cropping import crop_to_nonzero
+from ..resampling.default_resampling import compute_new_shape
+from ...utilities.find_class_by_name import recursive_find_python_class
+from ...utilities.plans_handling.plans_handler import PlansManager, ConfigurationManager
+
+NORMALIZATION_SEARCH_PATH = Path(__file__).resolve().parent.parent / "normalization"
 
 
 class DefaultPreprocessor(object):
@@ -205,7 +207,7 @@ class DefaultPreprocessor(object):
                    foreground_intensity_properties_per_channel: dict) -> np.ndarray:
         for c in range(data.shape[0]):
             scheme = configuration_manager.normalization_schemes[c]
-            normalizer_class = recursive_find_python_class(join(nnunetv2.__path__[0], "preprocessing", "normalization"),
+            normalizer_class = recursive_find_python_class(str(NORMALIZATION_SEARCH_PATH),
                                                            scheme,
                                                            'nnunetv2.preprocessing.normalization')
             if normalizer_class is None:

--- a/nnunetv2/preprocessing/resampling/utils.py
+++ b/nnunetv2/preprocessing/resampling/utils.py
@@ -1,12 +1,13 @@
+from pathlib import Path
 from typing import Callable
 
-import nnunetv2
-from batchgenerators.utilities.file_and_folder_operations import join
-from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
+from ...utilities.find_class_by_name import recursive_find_python_class
+
+RESAMPLING_SEARCH_PATH = Path(__file__).resolve().parent
 
 
 def recursive_find_resampling_fn_by_name(resampling_fn: str) -> Callable:
-    ret = recursive_find_python_class(join(nnunetv2.__path__[0], "preprocessing", "resampling"), resampling_fn,
+    ret = recursive_find_python_class(str(RESAMPLING_SEARCH_PATH), resampling_fn,
                                       'nnunetv2.preprocessing.resampling')
     if ret is None:
         raise RuntimeError("Unable to find resampling function named '%s'. Please make sure this fn is located in the "

--- a/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
+++ b/nnunetv2/training/nnUNetTrainer/nnUNetTrainer.py
@@ -45,14 +45,14 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 ANISO_THRESHOLD = 3 
 default_num_processes = 8 if 'nnUNet_def_n_proc' not in os.environ else int(os.environ['nnUNet_def_n_proc'])
-from nnunetv2.inference.export_prediction import export_prediction_from_logits, resample_and_save
-from nnunetv2.inference.predict_from_raw_data import nnUNetPredictor
-from nnunetv2.inference.sliding_window_prediction import compute_gaussian
-from nnunetv2.utilities.file_path_utilities import check_workers_alive_and_busy
-from nnunetv2.utilities.get_network_from_plans import get_network_from_plans
-from nnunetv2.utilities.helpers import empty_cache, dummy_context
-from nnunetv2.utilities.label_handling.label_handling import convert_labelmap_to_one_hot, determine_num_input_channels
-from nnunetv2.utilities.plans_handling.plans_handler import PlansManager
+from ...inference.export_prediction import export_prediction_from_logits, resample_and_save
+from ...inference.predict_from_raw_data import nnUNetPredictor
+from ...inference.sliding_window_prediction import compute_gaussian
+from ...utilities.file_path_utilities import check_workers_alive_and_busy
+from ...utilities.get_network_from_plans import get_network_from_plans
+from ...utilities.helpers import empty_cache, dummy_context
+from ...utilities.label_handling.label_handling import convert_labelmap_to_one_hot, determine_num_input_channels
+from ...utilities.plans_handling.plans_handler import PlansManager
 
 
 class nnUNetTrainer(object):

--- a/nnunetv2/utilities/get_network_from_plans.py
+++ b/nnunetv2/utilities/get_network_from_plans.py
@@ -2,7 +2,7 @@ import pydoc
 import warnings
 from typing import Union
 
-from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
+from .find_class_by_name import recursive_find_python_class
 from batchgenerators.utilities.file_and_folder_operations import join
 
 

--- a/nnunetv2/utilities/label_handling/label_handling.py
+++ b/nnunetv2/utilities/label_handling/label_handling.py
@@ -5,17 +5,18 @@ from typing import Union, List, Tuple, Type
 import numpy as np
 import torch
 from acvl_utils.cropping_and_padding.bounding_boxes import bounding_box_to_slice, insert_crop_into_image
-from batchgenerators.utilities.file_and_folder_operations import join
+from pathlib import Path
 
-import nnunetv2
-from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
-from nnunetv2.utilities.helpers import softmax_helper_dim0
+from ..find_class_by_name import recursive_find_python_class
+from ..helpers import softmax_helper_dim0
 
 from typing import TYPE_CHECKING
 
 # see https://adamj.eu/tech/2021/05/13/python-type-hints-how-to-fix-circular-imports/
 if TYPE_CHECKING:
-    from nnunetv2.utilities.plans_handling.plans_handler import PlansManager, ConfigurationManager
+    from ..plans_handling.plans_handler import PlansManager, ConfigurationManager
+
+LABEL_HANDLING_SEARCH_PATH = Path(__file__).resolve().parent
 
 
 class LabelManager(object):
@@ -250,7 +251,7 @@ def get_labelmanager_class_from_plans(plans: dict) -> Type[LabelManager]:
         print('No label manager specified in plans. Using default: LabelManager')
         return LabelManager
     else:
-        labelmanager_class = recursive_find_python_class(join(nnunetv2.__path__[0], "utilities", "label_handling"),
+        labelmanager_class = recursive_find_python_class(str(LABEL_HANDLING_SEARCH_PATH),
                                                          plans['label_manager'],
                                                          current_module="nnunetv2.utilities.label_handling")
         return labelmanager_class

--- a/nnunetv2/utilities/plans_handling/plans_handler.py
+++ b/nnunetv2/utilities/plans_handling/plans_handler.py
@@ -4,26 +4,30 @@ import warnings
 
 from copy import deepcopy
 from functools import lru_cache, partial
+from pathlib import Path
 from typing import Union, Tuple, List, Type, Callable
 
 import numpy as np
 import torch
 
-from nnunetv2.preprocessing.resampling.utils import recursive_find_resampling_fn_by_name
-import nnunetv2
-from batchgenerators.utilities.file_and_folder_operations import load_json, join
+from ...preprocessing.resampling.utils import recursive_find_resampling_fn_by_name
+from batchgenerators.utilities.file_and_folder_operations import load_json
 
-from nnunetv2.utilities.find_class_by_name import recursive_find_python_class
-from nnunetv2.utilities.label_handling.label_handling import get_labelmanager_class_from_plans
+from ..find_class_by_name import recursive_find_python_class
+from ..label_handling.label_handling import get_labelmanager_class_from_plans
 
 # see https://adamj.eu/tech/2021/05/13/python-type-hints-how-to-fix-circular-imports/
 from typing import TYPE_CHECKING
 from dynamic_network_architectures.building_blocks.helper import convert_dim_to_conv_op, get_matching_instancenorm
 
 if TYPE_CHECKING:
-    from nnunetv2.utilities.label_handling.label_handling import LabelManager
-    from nnunetv2.preprocessing.preprocessors.default_preprocessor import DefaultPreprocessor
-    from nnunetv2.experiment_planning.experiment_planners.default_experiment_planner import ExperimentPlanner
+    from ..label_handling.label_handling import LabelManager
+    from ...preprocessing.preprocessors.default_preprocessor import DefaultPreprocessor
+    from ...experiment_planning.experiment_planners.default_experiment_planner import ExperimentPlanner
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[2]
+PREPROCESSING_SEARCH_PATH = PACKAGE_ROOT / "preprocessing"
+EXPERIMENT_PLANNING_SEARCH_PATH = PACKAGE_ROOT / "experiment_planning"
 
 
 class ConfigurationManager(object):
@@ -108,7 +112,7 @@ class ConfigurationManager(object):
     @property
     @lru_cache(maxsize=1)
     def preprocessor_class(self) -> Type[DefaultPreprocessor]:
-        preprocessor_class = recursive_find_python_class(join(nnunetv2.__path__[0], "preprocessing"),
+        preprocessor_class = recursive_find_python_class(str(PREPROCESSING_SEARCH_PATH),
                                                          self.preprocessor_name,
                                                          current_module="nnunetv2.preprocessing")
         return preprocessor_class
@@ -297,7 +301,7 @@ class PlansManager(object):
     @lru_cache(maxsize=1)
     def experiment_planner_class(self) -> Type[ExperimentPlanner]:
         planner_name = self.experiment_planner_name
-        experiment_planner = recursive_find_python_class(join(nnunetv2.__path__[0], "experiment_planning"),
+        experiment_planner = recursive_find_python_class(str(EXPERIMENT_PLANNING_SEARCH_PATH),
                                                          planner_name,
                                                          current_module="nnunetv2.experiment_planning")
         return experiment_planner


### PR DESCRIPTION
## Summary
- replace intra-package absolute imports with relative imports
- derive package resource paths via `Path(__file__)` instead of importing `nnunetv2`

## Testing
- python -m compileall nnunetv2

------
https://chatgpt.com/codex/tasks/task_e_68c946c34e6883248d9da4ce22046d10